### PR TITLE
Fix extension initialization bugs

### DIFF
--- a/jupytergraffiti/graffiti_extension/main.js
+++ b/jupytergraffiti/graffiti_extension/main.js
@@ -12,17 +12,34 @@ define([
 ], (Jupyter, Graffiti, utils, storage, udacityUser) => {
   function load_ipython_extension() {
     console.log('Graffiti loaded:', Graffiti);
-    window.Graffiti = Graffiti;
-    udacityUser.setUser();
-    Graffiti.init();
 
-    Jupyter.notebook.events.on('kernel_ready.Kernel', (e) => { 
-      console.log('Graffiti: kernel ready, possible kernel restart.', e);
-      console.log('Reloading loader.js');
-      require(['jupytergraffiti/js/loader.js']);
-      utils.saveNotebook();
-    });
-    
+    const initExtension = () => {
+      window.Graffiti = Graffiti;
+      udacityUser.setUser();
+      Graffiti.init();
+  
+      Jupyter.notebook.events.on('kernel_ready.Kernel', () => { 
+        console.log('Graffiti: kernel ready, possible kernel restart.', e);
+        console.log('Reloading loader.js');
+        if (!udacityUser.token) {
+          udacityUser.setUser();
+        } 
+        require(['jupytergraffiti/js/loader.js']);
+        utils.saveNotebook();
+      });
+    }
+
+    // the notebook may have fully loaded before the nbextension gets loaded
+    // so the nbextension would miss the `notebook_loaded.Notebook` event
+    if (Jupyter.notebook._fully_loaded) {
+      console.log('Notebook is already fully loaded.');
+      initExtension();
+    } else {
+      Jupyter.notebook.events.on('notebook_loaded.Notebook', () => {
+        console.log('Notebook is loaded.');
+        initExtension();
+      })
+    }   
   }
 
   return {

--- a/jupytergraffiti/js/loader.js
+++ b/jupytergraffiti/js/loader.js
@@ -1,28 +1,27 @@
-if (window.Graffiti === undefined) {
-  define([
-    './graffiti.js',
-    './utils.js',
-    './storage.js',
-    './udacityUser.js'
-  ], (Graffiti,utils, storage, udacityUser) => {
-    console.log('Graffiti loaded:', Graffiti);
-    window.Graffiti = Graffiti;
-    udacityUser.setUser();
-    Graffiti.init();
+define([], () => {
+  if (window.Graffiti === undefined) {
+    require(['./graffiti.js', './utils.js', './storage.js', './udacityUser.js'],
+      (Graffiti, utils, storage, udacityUser) => {
+        console.log('Graffiti loaded:', Graffiti);
+        window.Graffiti = Graffiti;
+        udacityUser.setUser();
+        Graffiti.init();
 
-    Jupyter.notebook.events.on('kernel_reconnecting.Kernel', (e) => { 
-      console.log('kernel reconnecting');
+        Jupyter.notebook.events.on('kernel_reconnecting.Kernel', () => {
+          console.log('kernel reconnecting');
+        });
+
+        Jupyter.notebook.events.on('kernel_ready.Kernel', () => {
+          console.log('Graffiti: kernel ready, possible kernel restart.', e);
+          if (!udacityUser.token) {
+            udacityUser.setUser();
+          }
+          require(['./loader.js']);
+          utils.saveNotebook();
+        });
     });
-
-    Jupyter.notebook.events.on('kernel_ready.Kernel', (e) => { 
-      console.log('Graffiti: kernel ready, possible kernel restart.', e);
-      require(['jupytergraffiti/js/loader.js']);
-      utils.saveNotebook();
-    });
-
-  });
-} else {
-  console.log('Graffiti already instantiated, not reinitializing');
-}
-
+  } else {
+    console.log('Graffiti already instantiated, not reinitializing');
+  }
+});
 

--- a/jupytergraffiti/js/loader.js
+++ b/jupytergraffiti/js/loader.js
@@ -1,27 +1,31 @@
 define([], () => {
-  if (window.Graffiti === undefined) {
-    require(['./graffiti.js', './utils.js', './storage.js', './udacityUser.js'],
-      (Graffiti, utils, storage, udacityUser) => {
-        console.log('Graffiti loaded:', Graffiti);
-        window.Graffiti = Graffiti;
-        udacityUser.setUser();
-        Graffiti.init();
-
-        Jupyter.notebook.events.on('kernel_reconnecting.Kernel', () => {
-          console.log('kernel reconnecting');
-        });
-
-        Jupyter.notebook.events.on('kernel_ready.Kernel', () => {
-          console.log('Graffiti: kernel ready, possible kernel restart.', e);
-          if (!udacityUser.token) {
-            udacityUser.setUser();
-          }
-          require(['./loader.js']);
-          utils.saveNotebook();
-        });
-    });
-  } else {
+  if (window.Graffiti !== undefined) { 
     console.log('Graffiti already instantiated, not reinitializing');
+    return;
   }
-});
 
+  require([
+    './graffiti.js', 
+    './utils.js', 
+    './storage.js', 
+    './udacityUser.js'
+    ], (Graffiti, utils, storage, udacityUser) => {
+    console.log('Graffiti loaded:', Graffiti);
+    window.Graffiti = Graffiti;
+    udacityUser.setUser();
+    Graffiti.init();
+
+    Jupyter.notebook.events.on('kernel_reconnecting.Kernel', () => {
+      console.log('kernel reconnecting');
+    });
+
+    Jupyter.notebook.events.on('kernel_ready.Kernel', () => {
+      console.log('Graffiti: kernel ready, possible kernel restart.', e);
+      if (!udacityUser.token) {
+        udacityUser.setUser();
+      } 
+      require(['jupytergraffiti/js/loader.js']);
+      utils.saveNotebook();
+    });
+  });
+});


### PR DESCRIPTION
- Wait till notebook is fully loaded to initialize graffiti extension. This ensures metadata is loaded and ready to be processed.
- Move global if else inside loader module. This was causing issues in bundled js version, causing loader.js always to run along with main.js.
