### PR TITLE
Will/persistence bug 2

### DIFF
--- a/jupytergraffiti/js/audio.js
+++ b/jupytergraffiti/js/audio.js
@@ -71,7 +71,9 @@ define([
       const scalar = state.getPlayRateScalar();
       //const scalar = (rawScalar === 1.0 ? rawScalar : rawScalar * 0.85);
       //console.log('updateAudioPlaybackRate, scalar:', scalar);
-      audio.audioObj.playbackRate = scalar;
+      if (audio.audioObj !== undefined) { // make this defensive because if a user hits ESC before audio is fully loaded then the audioObj will not yet be defined
+        audio.audioObj.playbackRate = scalar;
+      }
     },
 
     // Special thanks to: https://developers.google.com/web/updates/2017/06/play-request-was-interrupted 

--- a/jupytergraffiti/js/graffiti.js
+++ b/jupytergraffiti/js/graffiti.js
@@ -3523,6 +3523,12 @@ define([
               stopProp = true;
               if ((activity === 'playing') || (activity === 'playbackPaused') || (activity === 'playbackPending') || (activity === 'scrubbing')) {
                 graffiti.cancelPlayback();
+                state.updateUsageStats({
+                  type:'play',
+                  data: {
+                    actions: ['userHitEscape']
+                  }
+                });
               }
               break;
             case 16: // shift key

--- a/jupytergraffiti/js/graffiti.js
+++ b/jupytergraffiti/js/graffiti.js
@@ -5504,6 +5504,9 @@ define([
         if (activity === 'playing') {
           console.log('Graffiti: Cannot start playing because already playing.');
           return;
+        } else if ((activity !== 'playbackPending') && (activity !== 'playbackPaused')) {
+          return; // do not try to start playback if playback was cancelled by the ESC key right before it could start (because of a slow network).
+                  // when this happens, activity will have been set back to 'idle'.
         }
 
         console.log('Graffiti: Starting playback, current activity:', activity);

--- a/jupytergraffiti/js/state.js
+++ b/jupytergraffiti/js/state.js
@@ -840,7 +840,9 @@ define([
               totalPlays: 0,
               totalPlaysRightAfterLoad: 0, // total of all plays that happened "from scratch", ie you just loaded the graffiti, not a play event triggered
                                            // by pressing play after you paused the graffiti
-              recordingDuration: state.history.duration
+              recordingDuration: state.history.duration,
+              userHitEscape: false, // becomes true if user uses escape key to terminate playback. If totalPlayTime is zero and this is true, it is probably because 
+                                    // the graffiti took too long to load and the user got impatient and terminated playback early.
             };
           }
           state.currentStatsKey = statsKey;
@@ -913,6 +915,9 @@ define([
                 usageRecord.totalPlays++;
                 state.usageStats.totalPlaysAllGraffiti++;
                 state.usageStats.totalUniquePlays = Object.keys(playStats).length;
+                break;
+              case 'userHitEscape':
+                usageRecord.userHitEscape = true;
                 break;
             }
           }


### PR DESCRIPTION
If user hit esc key to cancel playback before it loads, we entered a weird state. This corrects for that, and also logs when the user hit esc during playback (at any time) in stats.